### PR TITLE
utils: addition of make_mock_api_client

### DIFF
--- a/reana_pytest_commons/test_utils.py
+++ b/reana_pytest_commons/test_utils.py
@@ -26,12 +26,11 @@ from mock import Mock
 from reana_commons.api_client import BaseAPIClient
 
 
-def make_mock_api_client(component, server):
+def make_mock_api_client(component):
     mock_http_client, mock_result, mock_response = Mock(), Mock(), Mock()
     mock_response.status_code = 200
     mock_result.result.return_value = ('_', mock_response)
     mock_http_client.request.return_value = mock_result
     mock_api_client = BaseAPIClient(component,
-                                    server,
                                     http_client=mock_http_client)
     return mock_api_client._client

--- a/reana_pytest_commons/test_utils.py
+++ b/reana_pytest_commons/test_utils.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2018 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# REANA is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# REANA; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
+# Suite 330, Boston, MA 02111-1307, USA.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization or
+# submit itself to any jurisdiction.
+"""REANA Pytest Commons test utilities."""
+
+import click
+from mock import Mock
+from reana_commons.api_client import BaseAPIClient
+
+
+def make_mock_api_client(component, server):
+    mock_http_client, mock_result, mock_response = Mock(), Mock(), Mock()
+    mock_response.status_code = 200
+    mock_result.result.return_value = ('_', mock_response)
+    mock_http_client.request.return_value = mock_result
+    mock_api_client = BaseAPIClient(component,
+                                    server,
+                                    http_client=mock_http_client)
+    return mock_api_client._client

--- a/reana_pytest_commons/test_utils.py
+++ b/reana_pytest_commons/test_utils.py
@@ -3,22 +3,8 @@
 # This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA is free software; you can redistribute it and/or modify it under the
-# terms of the GNU General Public License as published by the Free Software
-# Foundation; either version 2 of the License, or (at your option) any later
-# version.
-#
-# REANA is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along with
-# REANA; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307, USA.
-#
-# In applying this license, CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 """REANA Pytest Commons test utilities."""
 
 import click

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     'jsonschema>=2.6.0,<2.7',
     'mock>=2.0',
     'pika>=0.12.0,<0.13',
-    'reana-commons>=0.3.1',
+    'reana-commons>=0.4.0.dev20181011,<0.5.0',
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'reana-commons>=0.3.1',
     'checksumdir>=1.1.4,<1.2',
     'click>=6.7,<7.0',
     'jsonschema>=2.6.0,<2.7',

--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,12 @@ setup_requires = [
 ]
 
 install_requires = [
-    'reana-commons>=0.3.1',
     'checksumdir>=1.1.4,<1.2',
     'click>=6.7,<7.0',
     'jsonschema>=2.6.0,<2.7',
+    'mock>=2.0',
     'pika>=0.12.0,<0.13',
+    'reana-commons>=0.3.1',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* ADD utility method to instantiate a SwaggerClient with a mock
  http_client, to be used for contract testing of REST APIs.

Closes https://github.com/reanahub/reana/issues/91

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>