### PR TITLE
global: license header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 notifications:
   email: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 include .dockerignore
 include LICENSE

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,21 +1,7 @@
 # This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA is free software; you can redistribute it and/or modify it under the
-# terms of the GNU General Public License as published by the Free Software
-# Foundation; either version 2 of the License, or (at your option) any later
-# version.
-#
-# REANA is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along with
-# REANA; if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-# Suite 330, Boston, MA 02111-1307, USA.
-#
-# In applying this license, CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization or
-# submit itself to any jurisdiction.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 -e .[all]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
 addopts = --pep8 --ignore=docs --cov=reana_pytest_commons --cov-report=term-missing

--- a/reana_pytest_commons/__init__.py
+++ b/reana_pytest_commons/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-Pytest-Commons."""
 

--- a/reana_pytest_commons/version.py
+++ b/reana_pytest_commons/version.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 """Version information for REANA-Pytest-Commons.
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 pydocstyle reana_pytest_commons && \
 isort -rc -c -df **/*.py && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 [aliases]
 test = pytest

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest fixtures for REANA."""
 
@@ -83,7 +83,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration for REANA-Pytest-Commons."""
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of REANA-Pytest-Commons.
+# This file is part of REANA.
 # Copyright (C) 2018 CERN.
 #
-# REANA-Pytest-Commons is free software; you can redistribute it and/or modify
-# it under the terms of the MIT License; see LICENSE file for more details.
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA-pytest-Commmons tests."""
 


### PR DESCRIPTION
* Amends license header in all files to the standardised version.

* Fixes license Trove classifier in ``setup.py``.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>